### PR TITLE
Suggest `npm start` instead of `ng serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In the project root:
 
 ```sh
 npm install
-ng serve
+npm start
 ```
 
 ### Backend


### PR DESCRIPTION
I guess not everyone will have ng installed globally.