### PR TITLE
feat(user-svc): is authorized should not return 401 when not authorized but a bool

### DIFF
--- a/server/internal/services/chat/http_add_message.go
+++ b/server/internal/services/chat/http_add_message.go
@@ -51,7 +51,7 @@ func (a *ChatService) AddMessage(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionMessageCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_add_thread.go
+++ b/server/internal/services/chat/http_add_thread.go
@@ -50,7 +50,7 @@ func (a *ChatService) AddThread(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionThreadCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_delete_message.go
+++ b/server/internal/services/chat/http_delete_message.go
@@ -44,7 +44,7 @@ func (a *ChatService) DeleteMessage(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionMessageDelete.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_delete_thread.go
+++ b/server/internal/services/chat/http_delete_thread.go
@@ -44,7 +44,7 @@ func (a *ChatService) DeleteThread(
 		UserSvcAPI.IsAuthorized(r.Context(), *chattypes.PermissionThreadCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_get_message.go
+++ b/server/internal/services/chat/http_get_message.go
@@ -44,7 +44,7 @@ func (a *ChatService) GetMessage(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionMessageCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_get_messages.go
+++ b/server/internal/services/chat/http_get_messages.go
@@ -44,7 +44,7 @@ func (a *ChatService) GetMessages(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionMessageView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_get_thread.go
+++ b/server/internal/services/chat/http_get_thread.go
@@ -44,7 +44,7 @@ func (a *ChatService) GetThread(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionThreadCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_get_threads.go
+++ b/server/internal/services/chat/http_get_threads.go
@@ -43,7 +43,7 @@ func (a *ChatService) GetThreads(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionThreadView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/chat/http_update_thread.go
+++ b/server/internal/services/chat/http_update_thread.go
@@ -44,7 +44,7 @@ func (a *ChatService) UpdateThread(
 		UserSvcAPI.IsAuthorized(r.Context(), *chat.PermissionThreadCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/config/http_save_config.go
+++ b/server/internal/services/config/http_save_config.go
@@ -49,7 +49,7 @@ func (cs *ConfigService) Save(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_build_image.go
+++ b/server/internal/services/container/http_build_image.go
@@ -36,7 +36,7 @@ func (dm *ContainerService) BuildImage(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_container_is_running.go
+++ b/server/internal/services/container/http_container_is_running.go
@@ -48,7 +48,7 @@ func (dm *ContainerService) ContainerIsRunning(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_container_summary.go
+++ b/server/internal/services/container/http_container_summary.go
@@ -49,7 +49,7 @@ func (dm *ContainerService) Summary(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_daemon_info.go
+++ b/server/internal/services/container/http_daemon_info.go
@@ -42,7 +42,7 @@ func (dm *ContainerService) DaemonInfo(
 		Body(openapi.UserSvcIsAuthorizedRequest{}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_host.go
+++ b/server/internal/services/container/http_host.go
@@ -44,7 +44,7 @@ func (dm *ContainerService) Host(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_image_pullable.go
+++ b/server/internal/services/container/http_image_pullable.go
@@ -49,7 +49,7 @@ func (dm *ContainerService) ImagePullable(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_list_containers.go
+++ b/server/internal/services/container/http_list_containers.go
@@ -49,7 +49,7 @@ func (dm *ContainerService) ListContainers(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_list_logs.go
+++ b/server/internal/services/container/http_list_logs.go
@@ -49,7 +49,7 @@ func (dm *ContainerService) ListLogs(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_run_container.go
+++ b/server/internal/services/container/http_run_container.go
@@ -48,7 +48,7 @@ func (dm *ContainerService) RunContainer(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/container/http_stop_container.go
+++ b/server/internal/services/container/http_stop_container.go
@@ -48,7 +48,7 @@ func (dm *ContainerService) StopContainer(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/data/http_create_object.go
+++ b/server/internal/services/data/http_create_object.go
@@ -44,7 +44,7 @@ func (g *DataService) Create(
 		UserSvcAPI.IsAuthorized(r.Context(), *data.PermissionObjectCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/data/http_create_objects.go
+++ b/server/internal/services/data/http_create_objects.go
@@ -29,7 +29,7 @@ func (g *DataService) CreateMany(
 		UserSvcAPI.IsAuthorized(r.Context(), *dynamictypes.PermissionObjectCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/data/http_delete_objects.go
+++ b/server/internal/services/data/http_delete_objects.go
@@ -44,7 +44,7 @@ func (g *DataService) DeleteObjects(
 		UserSvcAPI.IsAuthorized(r.Context(), *data.PermissionObjectDelete.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/data/http_query_objects.go
+++ b/server/internal/services/data/http_query_objects.go
@@ -50,7 +50,7 @@ func (g *DataService) Query(
 		UserSvcAPI.IsAuthorized(r.Context(), *data.PermissionObjectView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/data/http_update_objects.go
+++ b/server/internal/services/data/http_update_objects.go
@@ -46,7 +46,7 @@ func (g *DataService) UpdateObjects(
 		UserSvcAPI.IsAuthorized(r.Context(), *data.PermissionObjectEdit.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/data/http_upsert_object.go
+++ b/server/internal/services/data/http_upsert_object.go
@@ -47,7 +47,7 @@ func (g *DataService) Upsert(
 		UserSvcAPI.IsAuthorized(r.Context(), *data.PermissionObjectCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/data/http_upsert_objects.go
+++ b/server/internal/services/data/http_upsert_objects.go
@@ -43,7 +43,7 @@ func (g *DataService) SaveObjects(
 		UserSvcAPI.IsAuthorized(r.Context(), *data.PermissionObjectCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/deploy/http_delete_deployments.go
+++ b/server/internal/services/deploy/http_delete_deployments.go
@@ -43,7 +43,7 @@ func (ns *DeployService) DeleteDeployment(
 		UserSvcAPI.IsAuthorized(r.Context(), *deploy.PermissionDeploymentView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/deploy/http_list_deployments.go
+++ b/server/internal/services/deploy/http_list_deployments.go
@@ -42,7 +42,7 @@ func (ns *DeployService) ListDeployments(
 		UserSvcAPI.IsAuthorized(r.Context(), *deploy.PermissionDeploymentView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/deploy/http_save_deployments.go
+++ b/server/internal/services/deploy/http_save_deployments.go
@@ -43,7 +43,7 @@ func (ns *DeployService) SaveDeployment(
 		UserSvcAPI.IsAuthorized(r.Context(), *deploy.PermissionDeploymentView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/email/http_send_email.go
+++ b/server/internal/services/email/http_send_email.go
@@ -37,7 +37,7 @@ func (s *EmailService) SendEmail(w http.ResponseWriter, r *http.Request) {
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/file/http_get_download.go
+++ b/server/internal/services/file/http_get_download.go
@@ -49,7 +49,7 @@ func (fs *FileService) GetDownload(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/file/http_list_downloads.go
+++ b/server/internal/services/file/http_list_downloads.go
@@ -42,7 +42,7 @@ func (ds *FileService) ListDownloads(
 		UserSvcAPI.IsAuthorized(r.Context(), *file.PermissionDownloadView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/file/http_pause_download.go
+++ b/server/internal/services/file/http_pause_download.go
@@ -46,7 +46,7 @@ func (ds *FileService) PauseDownload(
 		UserSvcAPI.IsAuthorized(r.Context(), *file.PermissionDownloadEdit.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/file/http_serve_download.go
+++ b/server/internal/services/file/http_serve_download.go
@@ -151,7 +151,7 @@ func (fs *FileService) serveRemoteDownload(
 			},
 		).Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -172,7 +172,7 @@ func (fs *FileService) serveRemoteDownload(
 		ServeDownload(r.Context(), downloads[0].URL).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/file/http_serve_upload.go
+++ b/server/internal/services/file/http_serve_upload.go
@@ -147,7 +147,7 @@ func (fs *FileService) serveRemote(
 			},
 		).Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -168,7 +168,7 @@ func (fs *FileService) serveRemote(
 		ServeUpload(r.Context(), uploads[0].FileId).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/firehose/http_publish_event.go
+++ b/server/internal/services/firehose/http_publish_event.go
@@ -45,7 +45,7 @@ func (p *FirehoseService) Publish(w http.ResponseWriter,
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/firehose/http_subscribe_to_events.go
+++ b/server/internal/services/firehose/http_subscribe_to_events.go
@@ -42,7 +42,7 @@ func (p *FirehoseService) Subscribe(
 		UserSvcAPI.IsAuthorized(r.Context(), *firehose.PermissionFirehoseStream.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_default_status.go
+++ b/server/internal/services/model/http_default_status.go
@@ -46,7 +46,7 @@ func (ms *ModelService) DefaultStatus(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_get_model.go
+++ b/server/internal/services/model/http_get_model.go
@@ -50,7 +50,7 @@ func (ms *ModelService) Get(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_list_models.go
+++ b/server/internal/services/model/http_list_models.go
@@ -47,7 +47,7 @@ func (ms *ModelService) ListModels(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_list_platforms.go
+++ b/server/internal/services/model/http_list_platforms.go
@@ -46,7 +46,7 @@ func (ms *ModelService) ListPlatforms(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_make_default.go
+++ b/server/internal/services/model/http_make_default.go
@@ -44,7 +44,7 @@ func (ms *ModelService) MakeDefault(
 		UserSvcAPI.IsAuthorized(r.Context(), *model.PermissionModelEdit.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_start_default.go
+++ b/server/internal/services/model/http_start_default.go
@@ -43,7 +43,7 @@ func (ms *ModelService) StartDefault(
 		UserSvcAPI.IsAuthorized(r.Context(), *model.PermissionModelCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_start_model.go
+++ b/server/internal/services/model/http_start_model.go
@@ -51,7 +51,7 @@ func (ms *ModelService) StartSpecific(
 		UserSvcAPI.IsAuthorized(r.Context(), *model.PermissionModelCreate.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/model/http_status.go
+++ b/server/internal/services/model/http_status.go
@@ -49,7 +49,7 @@ func (ms *ModelService) Status(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/policy/http_check.go
+++ b/server/internal/services/policy/http_check.go
@@ -33,7 +33,7 @@ func (s *PolicyService) Check(
 		UserSvcAPI.IsAuthorized(r.Context(), *policy.PermissionTemplateEdit.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/policy/http_upsert_instance.go
+++ b/server/internal/services/policy/http_upsert_instance.go
@@ -32,7 +32,7 @@ func (s *PolicyService) UpsertInstance(
 		UserSvcAPI.IsAuthorized(r.Context(), *policy.PermissionInstanceEdit.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/prompt/http_list_prompts.go
+++ b/server/internal/services/prompt/http_list_prompts.go
@@ -45,7 +45,7 @@ func (p *PromptService) ListPrompts(
 		Body(openapi.UserSvcIsAuthorizedRequest{}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/prompt/http_remove_prompt.go
+++ b/server/internal/services/prompt/http_remove_prompt.go
@@ -44,7 +44,7 @@ func (p *PromptService) RemovePrompt(
 		Body(openapi.UserSvcIsAuthorizedRequest{}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/prompt/http_subscribe_to_prompt_responses.go
+++ b/server/internal/services/prompt/http_subscribe_to_prompt_responses.go
@@ -49,7 +49,7 @@ func (p *PromptService) SubscribeToPromptResponses(
 		Body(openapi.UserSvcIsAuthorizedRequest{}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_delete_definition.go
+++ b/server/internal/services/registry/http_delete_definition.go
@@ -36,7 +36,7 @@ func (rs *RegistryService) DeleteDefinition(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_delete_node.go
+++ b/server/internal/services/registry/http_delete_node.go
@@ -37,7 +37,7 @@ func (rs *RegistryService) DeleteNode(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_list_definitions.go
+++ b/server/internal/services/registry/http_list_definitions.go
@@ -32,7 +32,7 @@ func (rs *RegistryService) ListDefinitions(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_list_instances.go
+++ b/server/internal/services/registry/http_list_instances.go
@@ -39,7 +39,7 @@ func (rs *RegistryService) ListInstances(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_list_nodes.go
+++ b/server/internal/services/registry/http_list_nodes.go
@@ -49,7 +49,7 @@ func (ns *RegistryService) ListNodes(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_node_self.go
+++ b/server/internal/services/registry/http_node_self.go
@@ -51,7 +51,7 @@ func (ns *RegistryService) NodeSelf(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_register_instance.go
+++ b/server/internal/services/registry/http_register_instance.go
@@ -37,7 +37,7 @@ func (rs *RegistryService) RegisterInstance(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_remove_instance.go
+++ b/server/internal/services/registry/http_remove_instance.go
@@ -36,7 +36,7 @@ func (rs *RegistryService) RemoveInstance(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/registry/http_save_definition.go
+++ b/server/internal/services/registry/http_save_definition.go
@@ -31,7 +31,7 @@ func (rs *RegistryService) SaveDefinition(
 		UserSvcAPI.IsAuthorized(r.Context(), *registry.PermissionNodeView.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/secret/http_decrypt.go
+++ b/server/internal/services/secret/http_decrypt.go
@@ -45,7 +45,7 @@ func (cs *SecretService) Decrypt(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/secret/http_encrypt.go
+++ b/server/internal/services/secret/http_encrypt.go
@@ -45,7 +45,7 @@ func (cs *SecretService) Encrypt(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/secret/http_list_secrets.go
+++ b/server/internal/services/secret/http_list_secrets.go
@@ -42,7 +42,7 @@ func (cs *SecretService) ListSecrets(
 		UserSvcAPI.IsAuthorized(r.Context(), *secret.PermissionSecretList.Id).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/secret/http_remove_secrets.go
+++ b/server/internal/services/secret/http_remove_secrets.go
@@ -45,7 +45,7 @@ func (cs *SecretService) RemoveSecrets(
 		Body(openapi.UserSvcIsAuthorizedRequest{}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/secret/http_save_secrets.go
+++ b/server/internal/services/secret/http_save_secrets.go
@@ -52,7 +52,7 @@ func (cs *SecretService) SaveSecrets(
 		Body(openapi.UserSvcIsAuthorizedRequest{}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/secret/http_secure.go
+++ b/server/internal/services/secret/http_secure.go
@@ -44,7 +44,7 @@ func (cs *SecretService) Secure(
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/source/http_checkout_repo.go
+++ b/server/internal/services/source/http_checkout_repo.go
@@ -43,7 +43,7 @@ func (s *SourceService) CheckoutRepo(w http.ResponseWriter,
 		}).
 		Execute()
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/server/internal/services/user/http_add_user_to_organization.go
+++ b/server/internal/services/user/http_add_user_to_organization.go
@@ -47,7 +47,7 @@ func (s *UserService) AddUserToOrganization(
 	organizationId := mux.Vars(r)["organizationId"]
 	userId := mux.Vars(r)["userId"]
 
-	usr, err := s.isAuthorized(
+	usr, _, err := s.isAuthorized(
 		r,
 		user.PermissionOrganizationAddUser.Id,
 		nil,

--- a/server/internal/services/user/http_add_user_to_organization.go
+++ b/server/internal/services/user/http_add_user_to_organization.go
@@ -47,15 +47,20 @@ func (s *UserService) AddUserToOrganization(
 	organizationId := mux.Vars(r)["organizationId"]
 	userId := mux.Vars(r)["userId"]
 
-	usr, _, err := s.isAuthorized(
+	usr, isAuthorized, err := s.isAuthorized(
 		r,
 		user.PermissionOrganizationAddUser.Id,
 		nil,
 		nil,
 	)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_assign_permissions.go
+++ b/server/internal/services/user/http_assign_permissions.go
@@ -45,7 +45,7 @@ func (s *UserService) AssignPermissions(
 ) {
 
 	// @todo add proper permission here
-	_, err := s.isAuthorized(r, user.PermissionPermissionAssign.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionPermissionAssign.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_assign_permissions.go
+++ b/server/internal/services/user/http_assign_permissions.go
@@ -45,10 +45,15 @@ func (s *UserService) AssignPermissions(
 ) {
 
 	// @todo add proper permission here
-	_, _, err := s.isAuthorized(r, user.PermissionPermissionAssign.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionPermissionAssign.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_assign_role.go
+++ b/server/internal/services/user/http_assign_role.go
@@ -51,7 +51,12 @@ func (s *UserService) AssignRole(
 
 	authorizer := sdk.AuthorizerImpl{}
 	claim, err := authorizer.ParseJWTFromRequest(s.publicKeyPem, r)
-	if err != nil || claim == nil {
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	if claim == nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte("Unauthorized"))
 		return

--- a/server/internal/services/user/http_change_password.go
+++ b/server/internal/services/user/http_change_password.go
@@ -38,7 +38,7 @@ import (
 // @Router /user-svc/change-password [post]
 func (s *UserService) ChangePassword(w http.ResponseWriter, r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_change_password.go
+++ b/server/internal/services/user/http_change_password.go
@@ -38,10 +38,15 @@ import (
 // @Router /user-svc/change-password [post]
 func (s *UserService) ChangePassword(w http.ResponseWriter, r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_create_organization.go
+++ b/server/internal/services/user/http_create_organization.go
@@ -44,15 +44,20 @@ func (s *UserService) CreateOrganization(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	usr, _, err := s.isAuthorized(
+	usr, isAuthorized, err := s.isAuthorized(
 		r,
 		user.PermissionOrganizationCreate.Id,
 		nil,
 		nil,
 	)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_create_organization.go
+++ b/server/internal/services/user/http_create_organization.go
@@ -44,7 +44,7 @@ func (s *UserService) CreateOrganization(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	usr, err := s.isAuthorized(
+	usr, _, err := s.isAuthorized(
 		r,
 		user.PermissionOrganizationCreate.Id,
 		nil,

--- a/server/internal/services/user/http_create_role.go
+++ b/server/internal/services/user/http_create_role.go
@@ -43,10 +43,15 @@ import (
 // @Router /user-svc/role [post]
 func (s *UserService) CreateRole(w http.ResponseWriter, r *http.Request) {
 
-	rsp, _, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
+	rsp, isAuthorized, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_create_role.go
+++ b/server/internal/services/user/http_create_role.go
@@ -43,7 +43,7 @@ import (
 // @Router /user-svc/role [post]
 func (s *UserService) CreateRole(w http.ResponseWriter, r *http.Request) {
 
-	rsp, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
+	rsp, _, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_create_user.go
+++ b/server/internal/services/user/http_create_user.go
@@ -37,10 +37,15 @@ func (s *UserService) CreateUser(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionUserCreate.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionUserCreate.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_create_user.go
+++ b/server/internal/services/user/http_create_user.go
@@ -37,7 +37,7 @@ func (s *UserService) CreateUser(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionUserCreate.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionUserCreate.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_delete_role.go
+++ b/server/internal/services/user/http_delete_role.go
@@ -39,7 +39,7 @@ import (
 // @Router /user-svc/role/{roleId} [delete]
 func (s *UserService) DeleteRole(w http.ResponseWriter, r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionRoleDelete.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionRoleDelete.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_delete_role.go
+++ b/server/internal/services/user/http_delete_role.go
@@ -39,10 +39,15 @@ import (
 // @Router /user-svc/role/{roleId} [delete]
 func (s *UserService) DeleteRole(w http.ResponseWriter, r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionRoleDelete.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionRoleDelete.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_delete_user.go
+++ b/server/internal/services/user/http_delete_user.go
@@ -38,10 +38,15 @@ import (
 // @Router /user-svc/user/{userId} [delete]
 func (s *UserService) DeleteUser(w http.ResponseWriter, r *http.Request) {
 
-	usr, _, err := s.isAuthorized(r, user.PermissionUserDelete.Id, nil, nil)
+	usr, isAuthorized, err := s.isAuthorized(r, user.PermissionUserDelete.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_delete_user.go
+++ b/server/internal/services/user/http_delete_user.go
@@ -38,7 +38,7 @@ import (
 // @Router /user-svc/user/{userId} [delete]
 func (s *UserService) DeleteUser(w http.ResponseWriter, r *http.Request) {
 
-	usr, err := s.isAuthorized(r, user.PermissionUserDelete.Id, nil, nil)
+	usr, _, err := s.isAuthorized(r, user.PermissionUserDelete.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_get_permissions.go
+++ b/server/internal/services/user/http_get_permissions.go
@@ -37,10 +37,15 @@ func (s *UserService) GetPermissions(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_get_permissions.go
+++ b/server/internal/services/user/http_get_permissions.go
@@ -37,7 +37,7 @@ func (s *UserService) GetPermissions(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_get_roles.go
+++ b/server/internal/services/user/http_get_roles.go
@@ -36,10 +36,15 @@ func (s *UserService) GetRoles(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_get_roles.go
+++ b/server/internal/services/user/http_get_roles.go
@@ -36,7 +36,7 @@ func (s *UserService) GetRoles(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_get_users.go
+++ b/server/internal/services/user/http_get_users.go
@@ -39,10 +39,15 @@ func (s *UserService) GetUsers(
 	r *http.Request,
 ) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionUserView.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionUserView.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_get_users.go
+++ b/server/internal/services/user/http_get_users.go
@@ -39,7 +39,7 @@ func (s *UserService) GetUsers(
 	r *http.Request,
 ) {
 
-	_, err := s.isAuthorized(r, user.PermissionUserView.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionUserView.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_list_grants.go
+++ b/server/internal/services/user/http_list_grants.go
@@ -41,7 +41,7 @@ func (s *UserService) ListGrants(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_list_grants.go
+++ b/server/internal/services/user/http_list_grants.go
@@ -41,10 +41,15 @@ func (s *UserService) ListGrants(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionRoleView.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_list_invites.go
+++ b/server/internal/services/user/http_list_invites.go
@@ -35,7 +35,7 @@ import (
 // @Router /user-svc/invites [post]
 func (s *UserService) ListInvites(w http.ResponseWriter, r *http.Request) {
 
-	usr, err := s.isAuthorized(r, user.PermissionInviteView.Id, nil, nil)
+	usr, _, err := s.isAuthorized(r, user.PermissionInviteView.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_list_invites.go
+++ b/server/internal/services/user/http_list_invites.go
@@ -35,10 +35,15 @@ import (
 // @Router /user-svc/invites [post]
 func (s *UserService) ListInvites(w http.ResponseWriter, r *http.Request) {
 
-	usr, _, err := s.isAuthorized(r, user.PermissionInviteView.Id, nil, nil)
+	usr, isAuthorized, err := s.isAuthorized(r, user.PermissionInviteView.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_remove_user_from_organization.go
+++ b/server/internal/services/user/http_remove_user_from_organization.go
@@ -47,15 +47,20 @@ func (s *UserService) RemoveUserFromOrganization(
 	organizationId := mux.Vars(r)["organizationId"]
 	userId := mux.Vars(r)["userId"]
 
-	usr, _, err := s.isAuthorized(
+	usr, isAuthorized, err := s.isAuthorized(
 		r,
 		user.PermissionOrganizationCreate.Id,
 		nil,
 		nil,
 	)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_remove_user_from_organization.go
+++ b/server/internal/services/user/http_remove_user_from_organization.go
@@ -47,7 +47,7 @@ func (s *UserService) RemoveUserFromOrganization(
 	organizationId := mux.Vars(r)["organizationId"]
 	userId := mux.Vars(r)["userId"]
 
-	usr, err := s.isAuthorized(
+	usr, _, err := s.isAuthorized(
 		r,
 		user.PermissionOrganizationCreate.Id,
 		nil,

--- a/server/internal/services/user/http_reset_password.go
+++ b/server/internal/services/user/http_reset_password.go
@@ -43,10 +43,15 @@ func (s *UserService) ResetPassword(
 	r *http.Request,
 ) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_reset_password.go
+++ b/server/internal/services/user/http_reset_password.go
@@ -43,7 +43,7 @@ func (s *UserService) ResetPassword(
 	r *http.Request,
 ) {
 
-	_, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionUserPasswordChange.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_save_grants.go
+++ b/server/internal/services/user/http_save_grants.go
@@ -41,7 +41,7 @@ import (
 // @Router /user-svc/grants [put]
 func (s *UserService) SaveGrants(w http.ResponseWriter, r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_save_grants.go
+++ b/server/internal/services/user/http_save_grants.go
@@ -41,10 +41,15 @@ import (
 // @Router /user-svc/grants [put]
 func (s *UserService) SaveGrants(w http.ResponseWriter, r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionRoleCreate.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_save_invites.go
+++ b/server/internal/services/user/http_save_invites.go
@@ -48,7 +48,7 @@ import (
 // @Router /user-svc/invites [put]
 func (s *UserService) SaveInvites(w http.ResponseWriter, r *http.Request) {
 
-	usr, err := s.isAuthorized(r, user.PermissionInviteEdit.Id, nil, nil)
+	usr, _, err := s.isAuthorized(r, user.PermissionInviteEdit.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_save_invites.go
+++ b/server/internal/services/user/http_save_invites.go
@@ -48,10 +48,15 @@ import (
 // @Router /user-svc/invites [put]
 func (s *UserService) SaveInvites(w http.ResponseWriter, r *http.Request) {
 
-	usr, _, err := s.isAuthorized(r, user.PermissionInviteEdit.Id, nil, nil)
+	usr, isAuthorized, err := s.isAuthorized(r, user.PermissionInviteEdit.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_save_permissions.go
+++ b/server/internal/services/user/http_save_permissions.go
@@ -45,7 +45,7 @@ func (s *UserService) SavePermissions(
 	r *http.Request,
 ) {
 
-	usr, err := s.isAuthorized(r, user.PermissionPermissionCreate.Id, nil, nil)
+	usr, _, err := s.isAuthorized(r, user.PermissionPermissionCreate.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_save_permissions.go
+++ b/server/internal/services/user/http_save_permissions.go
@@ -45,10 +45,15 @@ func (s *UserService) SavePermissions(
 	r *http.Request,
 ) {
 
-	usr, _, err := s.isAuthorized(r, user.PermissionPermissionCreate.Id, nil, nil)
+	usr, isAuthorized, err := s.isAuthorized(r, user.PermissionPermissionCreate.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_save_user.go
+++ b/server/internal/services/user/http_save_user.go
@@ -38,10 +38,15 @@ import (
 // @Router /user-svc/user/{userId} [put]
 func (s *UserService) SaveUser(w http.ResponseWriter, r *http.Request) {
 
-	_, _, err := s.isAuthorized(r, user.PermissionUserEdit.Id, nil, nil)
+	_, isAuthorized, err := s.isAuthorized(r, user.PermissionUserEdit.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 

--- a/server/internal/services/user/http_save_user.go
+++ b/server/internal/services/user/http_save_user.go
@@ -38,7 +38,7 @@ import (
 // @Router /user-svc/user/{userId} [put]
 func (s *UserService) SaveUser(w http.ResponseWriter, r *http.Request) {
 
-	_, err := s.isAuthorized(r, user.PermissionUserEdit.Id, nil, nil)
+	_, _, err := s.isAuthorized(r, user.PermissionUserEdit.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_set_role_permissions.go
+++ b/server/internal/services/user/http_set_role_permissions.go
@@ -42,7 +42,7 @@ func (s *UserService) SetRolePermissions(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	usr, err := s.isAuthorized(r, user.PermissionRoleEdit.Id, nil, nil)
+	usr, _, err := s.isAuthorized(r, user.PermissionRoleEdit.Id, nil, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(err.Error()))

--- a/server/internal/services/user/http_set_role_permissions.go
+++ b/server/internal/services/user/http_set_role_permissions.go
@@ -42,10 +42,15 @@ func (s *UserService) SetRolePermissions(
 	w http.ResponseWriter,
 	r *http.Request) {
 
-	usr, _, err := s.isAuthorized(r, user.PermissionRoleEdit.Id, nil, nil)
+	usr, isAuthorized, err := s.isAuthorized(r, user.PermissionRoleEdit.Id, nil, nil)
 	if err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
+		return
+	}
+	if !isAuthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte("Unauthorized"))
 		return
 	}
 


### PR DESCRIPTION
This reverts commit 23ae334cc2dbf13523cf2f67c8260db9dc38305b.

Also fixes is_authorized behaviour, ie:

$ oo n ls
Error: failed to list nodes: 500 Internal Server Error

->

$ oo n ls
Error: failed to list nodes: 401 Unauthorized
