### PR TITLE
feat: support testing microservices with 1backend

### DIFF
--- a/.github/workflows/backend-tests.yaml
+++ b/.github/workflows/backend-tests.yaml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Run tests
         run: |
+          # Some tests invoke the server cli itself
+          go install
+
           go test ./... -v -failfast -timeout=30s
 
           docker rm -f mypostgres

--- a/docs-source/docs/built-in-services/user-svc.md
+++ b/docs-source/docs/built-in-services/user-svc.md
@@ -166,7 +166,7 @@ Examples of Role Ownership
 
 - A user with the slug joe-doe owns roles like joe-doe:any-custom-role.
 - A user with any slug who has the role my-service:admin owns my-service:user.
-- A user with any slug who has the role user-svc:org:{%orgId}:admin owns user-svc:org:{%orgId}:user.
+- A user with any slug who has the role user-svc:org:{$orgId}:admin owns user-svc:org:{$orgId}:user.
 
 By enforcing role ownership rules, the system ensures that roles are only assigned by authorized users, preventing privilege escalation and maintaining security within the organization.
 

--- a/sdk/go/datastore_factory.go
+++ b/sdk/go/datastore_factory.go
@@ -63,6 +63,9 @@ func NewDataStoreFactory(options DataStoreConfig) (DataStoreFactory, error) {
 		options.HomeDir = homeDir
 	}
 
+	if options.TablePrefix == "" {
+		options.TablePrefix = os.Getenv("OB_DB_PREFIX")
+	}
 	if options.Test && options.TablePrefix == "" {
 		options.TablePrefix = Id("test") + "_"
 	}

--- a/sdk/go/homedir.go
+++ b/sdk/go/homedir.go
@@ -23,8 +23,14 @@ const onebackendFolder = ".1backend"
 
 type HomeDirOptions struct {
 	Test bool
+
+	// The config folder name. Not the full path.
+	// This mostly exists to support running multiple local
+	// servers for testing purposes.
+	ConfigFolder string
 }
 
+// HomeDir of the 1backend server
 func HomeDir(options HomeDirOptions) (string, error) {
 	var (
 		homeDir string
@@ -42,7 +48,11 @@ func HomeDir(options HomeDirOptions) (string, error) {
 		if err != nil {
 			return "", errors.Wrap(err, "homedir creation failed")
 		}
-		homeDir = path.Join(homeDir, onebackendFolder)
+		fold := onebackendFolder
+		if options.ConfigFolder != "" {
+			fold = options.ConfigFolder
+		}
+		homeDir = path.Join(homeDir, fold)
 	}
 
 	return homeDir, nil

--- a/sdk/go/router/router.go
+++ b/sdk/go/router/router.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 )
 
+// GLOBALS.
+// Abhorrent.
+
 var port = "58231"
 
 const address = "http://127.0.0.1"

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -1,0 +1,193 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type Options struct {
+	Port        int
+	GpuPlatform string
+
+	Az         string
+	Region     string
+	LLMHost    string
+	VolumeName string
+	ConfigPath string
+
+	// eg. mysql, postgres
+	Db string
+
+	// Connection string eg.
+	// "postgres://postgres:mysecretpassword@localhost:5432/mydatabase?sslmode=disable"
+	DbConnectionString string
+
+	// Crucial for distributed features.
+	// Please see the documentation for the envar OB_NODE_ID
+	NodeId string
+
+	// DbPrefix allows us to have isolated envs for different test cases
+	// but still make multiple nodes in those test cases use the same
+	// shard of the db.
+	DbPrefix string
+
+	SourceControlToken  string
+	SecretEncryptionKey string
+
+	// URL of the local 1Backend server instance
+	Url string
+
+	// Test mode if true will cause the localstore to
+	// save data into random temporary folders.
+	Test bool
+
+	// HomeDir is the 1Backend config/data/uploads/downloads directory.
+	// For tests it's something like /tmp/1backend-2698538720/
+	// For live it's /home/youruser/.1backend
+	HomeDir string
+}
+
+type ServerProcess struct {
+	Cmd    *exec.Cmd
+	Url    string
+	Stdout *bytes.Buffer
+	Stderr *bytes.Buffer
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	Port   string
+}
+
+func findAvailablePort() (string, error) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return "", err
+	}
+	defer listener.Close()
+	return fmt.Sprintf("%v", listener.Addr().(*net.TCPAddr).Port), nil
+}
+
+func StartServer(options Options) (*ServerProcess, error) {
+	var (
+		port string
+		err  error
+	)
+
+	if options.Url == "" {
+		port, err = findAvailablePort()
+		if err != nil {
+			return nil, err
+		}
+
+		options.Url = fmt.Sprintf("http://127.0.0.1:%v", port)
+	}
+
+	if port == "" {
+		port = "58231"
+	}
+
+	envVars := map[string]string{
+		"OB_GPU_PLATFORM":         options.GpuPlatform,
+		"OB_SERVER_URL":           options.Url,
+		"OB_NODE_ID":              options.NodeId,
+		"OB_AZ":                   options.Az,
+		"OB_REGION":               options.Region,
+		"OB_LLM_HOST":             options.LLMHost,
+		"OB_VOLUME_NAME":          options.VolumeName,
+		"OB_DB_PREFIX":            options.DbPrefix,
+		"OB_DB":                   options.Db,
+		"OB_DB_CONNECTION_STRING": options.DbConnectionString,
+		"OB_ENCRYPTION_KEY":       options.SecretEncryptionKey,
+	}
+
+	for key, value := range envVars {
+		if value == "" {
+			if envValue, exists := os.LookupEnv(key); exists {
+				envVars[key] = envValue
+			}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "server")
+
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	for key, value := range envVars {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = io.MultiWriter(stdout)
+	cmd.Stderr = io.MultiWriter(stderr)
+
+	server := &ServerProcess{
+		Cmd:    cmd,
+		Stdout: stdout,
+		Stderr: stderr,
+		cancel: cancel,
+		Port:   port,
+		Url:    fmt.Sprintf("http://127.0.0.1:%v", port),
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, errors.Wrap(err, "server failed to start")
+	}
+
+	// **Wait until first line of output appears**
+	waitChan := make(chan struct{})
+	go func() {
+		for {
+			time.Sleep(10 * time.Millisecond)
+			if stdout.Len() > 0 || stderr.Len() > 0 {
+				close(waitChan)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-waitChan:
+	case <-time.After(5 * time.Second): // Timeout in case the server fails to start
+		server.Stop()
+		return nil, errors.New("server did not produce output within 5 seconds")
+	}
+
+	server.wg.Add(1)
+	go func() {
+		defer server.wg.Done()
+		cmd.Wait()
+	}()
+
+	return server, nil
+}
+
+func (s *ServerProcess) Stop() {
+	s.cancel()
+	time.Sleep(100 * time.Millisecond) // Give process some time to exit
+	_ = s.Cmd.Process.Kill()
+	s.wg.Wait()
+}
+
+func (s *ServerProcess) Output() string {
+	return s.Stdout.String() + s.Stderr.String()
+}
+
+func (s *ServerProcess) Cleanup(t *testing.T) {
+	if t.Failed() {
+		fmt.Println("=== SERVER OUTPUT ===")
+		fmt.Print(s.Stdout.String() + s.Stderr.String())
+		fmt.Println("=== END OF SERVER OUTPUT ===")
+	}
+
+	s.Stop()
+}

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -186,14 +186,14 @@ func StartServer(options Options) (*ServerProcess, error) {
 		return nil, errors.Wrap(err, "server failed to start")
 	}
 
-	timeout := 7 * time.Second
+	timeout := 10 * time.Second
 
 	select {
 	case <-waitChan:
 	case <-time.After(timeout): // Timeout in case the server fails to start
 		server.Stop()
 		return nil, errors.Errorf(
-			"server did not produce output within %v seconds", timeout,
+			"server did not produce output within %v", timeout,
 		)
 	}
 

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -155,9 +155,8 @@ func StartServer(options Options) (*ServerProcess, error) {
 		for {
 			time.Sleep(10 * time.Millisecond)
 			output := stdout.String() + stderr.String()
+
 			if strings.Contains(output, "Server started") {
-				// hmmm
-				time.Sleep(1500 * time.Millisecond)
 				close(waitChan)
 				return
 			}
@@ -168,7 +167,9 @@ func StartServer(options Options) (*ServerProcess, error) {
 	case <-waitChan:
 	case <-time.After(5 * time.Second): // Timeout in case the server fails to start
 		server.Stop()
-		return nil, errors.New("server did not produce output within 5 seconds")
+		return nil, errors.New(
+			"server did not produce output within 5 seconds: ",
+		)
 	}
 
 	server.wg.Add(1)

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	sdk "github.com/1backend/1backend/sdk/go"
 	"github.com/pkg/errors"
 )
 
@@ -93,6 +94,10 @@ func StartServer(options Options) (*ServerProcess, error) {
 
 	if port == "" {
 		port = "58231"
+	}
+
+	if options.Test {
+		options.DbPrefix = sdk.Id("t")
 	}
 
 	envVars := map[string]string{

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -153,7 +154,10 @@ func StartServer(options Options) (*ServerProcess, error) {
 	go func() {
 		for {
 			time.Sleep(10 * time.Millisecond)
-			if stdout.Len() > 0 || stderr.Len() > 0 {
+			output := stdout.String() + stderr.String()
+			if strings.Contains(output, "Server started") {
+				// hmmm
+				time.Sleep(1000 * time.Millisecond)
 				close(waitChan)
 				return
 			}

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -157,7 +157,7 @@ func StartServer(options Options) (*ServerProcess, error) {
 			output := stdout.String() + stderr.String()
 			if strings.Contains(output, "Server started") {
 				// hmmm
-				time.Sleep(1000 * time.Millisecond)
+				time.Sleep(1500 * time.Millisecond)
 				close(waitChan)
 				return
 			}

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -186,7 +186,7 @@ func StartServer(options Options) (*ServerProcess, error) {
 		return nil, errors.Wrap(err, "server failed to start")
 	}
 
-	timeout := 10 * time.Second
+	timeout := 15 * time.Second
 
 	select {
 	case <-waitChan:

--- a/sdk/go/test/test_server.go
+++ b/sdk/go/test/test_server.go
@@ -186,12 +186,14 @@ func StartServer(options Options) (*ServerProcess, error) {
 		return nil, errors.Wrap(err, "server failed to start")
 	}
 
+	timeout := 7 * time.Second
+
 	select {
 	case <-waitChan:
-	case <-time.After(5 * time.Second): // Timeout in case the server fails to start
+	case <-time.After(timeout): // Timeout in case the server fails to start
 		server.Stop()
-		return nil, errors.New(
-			"server did not produce output within 5 seconds: ",
+		return nil, errors.Errorf(
+			"server did not produce output within %v seconds", timeout,
 		)
 	}
 

--- a/server/internal/services/data/http_create_object.go
+++ b/server/internal/services/data/http_create_object.go
@@ -48,6 +48,7 @@ func (g *DataService) Create(
 		w.Write([]byte(err.Error()))
 		return
 	}
+
 	if !isAuthRsp.GetAuthorized() {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(`Unauthorized`))

--- a/server/internal/services/user/http_create_role_test.go
+++ b/server/internal/services/user/http_create_role_test.go
@@ -2,41 +2,34 @@ package userservice_test
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	openapi "github.com/1backend/1backend/clients/go"
 	sdk "github.com/1backend/1backend/sdk/go"
-	"github.com/1backend/1backend/server/internal/di"
+	"github.com/1backend/1backend/sdk/go/test"
 )
 
 func TestCreateRole(t *testing.T) {
-	hs := &di.HandlerSwitcher{}
-	server := httptest.NewServer(hs)
-	defer server.Close()
+	t.Parallel()
 
-	options := &di.Options{
+	server, err := test.StartServer(test.Options{
 		Test: true,
-		Url:  server.URL,
-	}
-	universe, err := di.BigBang(options)
+	})
 	require.NoError(t, err)
+	defer server.Cleanup(t)
 
-	hs.UpdateHandler(universe.Router)
-
-	err = universe.StarterFunc()
-	require.NoError(t, err)
+	clientFactory := sdk.NewApiClientFactory(server.Url)
 
 	token, err := sdk.RegisterUserAccount(
-		options.ClientFactory.Client().UserSvcAPI,
+		clientFactory.Client().UserSvcAPI,
 		"someuser",
 		"pw123",
 		"Some name",
 	)
 	require.NoError(t, err)
-	userClient := options.ClientFactory.Client(sdk.WithToken(token.Token))
+	userClient := clientFactory.Client(sdk.WithToken(token.Token))
 
 	ctx := context.Background()
 

--- a/server/internal/services/user/http_is_authorized.go
+++ b/server/internal/services/user/http_is_authorized.go
@@ -110,8 +110,10 @@ func (s *UserService) isAuthorized(
 		datastore.Equals(datastore.Field("userId"), usr.Id),
 	).Find()
 	if err != nil {
+
 		return nil, false, err
 	}
+
 	roleIds := []string{}
 	for _, role := range roleLinks {
 		roleIds = append(roleIds, role.(*user.UserRoleLink).RoleId)

--- a/server/internal/services/user/http_save_invites_test.go
+++ b/server/internal/services/user/http_save_invites_test.go
@@ -2,19 +2,19 @@ package userservice_test
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/1backend/1backend/sdk/go"
 	"github.com/1backend/1backend/sdk/go/test"
-	"github.com/1backend/1backend/server/internal/di"
 
 	openapi "github.com/1backend/1backend/clients/go"
 )
 
 func TestInviteForUnregistered(t *testing.T) {
+	t.Parallel()
+
 	server, err := test.StartServer(test.Options{
 		Test: true,
 	})
@@ -108,22 +108,16 @@ func TestInviteForUnregistered(t *testing.T) {
 }
 
 func TestInviteForRegisteredUser(t *testing.T) {
-	hs := &di.HandlerSwitcher{}
-	server := httptest.NewServer(hs)
-	defer server.Close()
+	t.Parallel()
 
-	options := &di.Options{
+	server, err := test.StartServer(test.Options{
 		Test: true,
-		Url:  server.URL,
-	}
-	universe, err := di.BigBang(options)
+	})
 	require.NoError(t, err)
+	defer server.Cleanup(t)
 
-	hs.UpdateHandler(universe.Router)
-	err = universe.StarterFunc()
-	require.NoError(t, err)
-
-	manyClients, _, err := test.MakeClients(options.ClientFactory, 1)
+	clientFactory := sdk.NewApiClientFactory(server.Url)
+	manyClients, _, err := test.MakeClients(clientFactory, 1)
 	require.NoError(t, err)
 
 	userClient := manyClients[0]
@@ -172,12 +166,12 @@ func TestInviteForRegisteredUser(t *testing.T) {
 			Execute()
 		require.NoError(t, err)
 
-		publicKeyRsp, _, err := options.ClientFactory.Client().
+		publicKeyRsp, _, err := clientFactory.Client().
 			UserSvcAPI.GetPublicKey(context.Background()).
 			Execute()
 		require.NoError(t, err)
 
-		claim, err := options.Authorizer.ParseJWT(
+		claim, err := sdk.AuthorizerImpl{}.ParseJWT(
 			publicKeyRsp.PublicKey,
 			loginRsp.Token.Token,
 		)
@@ -194,22 +188,16 @@ func TestInviteForRegisteredUser(t *testing.T) {
 }
 
 func TestListInviteAuthorization(t *testing.T) {
-	hs := &di.HandlerSwitcher{}
-	server := httptest.NewServer(hs)
-	defer server.Close()
+	t.Parallel()
 
-	options := &di.Options{
+	server, err := test.StartServer(test.Options{
 		Test: true,
-		Url:  server.URL,
-	}
-	universe, err := di.BigBang(options)
+	})
 	require.NoError(t, err)
+	defer server.Cleanup(t)
 
-	hs.UpdateHandler(universe.Router)
-	err = universe.StarterFunc()
-	require.NoError(t, err)
-
-	manyClients, tokens, err := test.MakeClients(options.ClientFactory, 2)
+	clientFactory := sdk.NewApiClientFactory(server.Url)
+	manyClients, tokens, err := test.MakeClients(clientFactory, 2)
 	require.NoError(t, err)
 
 	userClient := manyClients[0]
@@ -255,7 +243,7 @@ func TestListInviteAuthorization(t *testing.T) {
 		require.Len(t, rsp.Invites[0].OwnerIds, 0)
 	})
 
-	secondUserClient, _, err = test.LoggedInClient(options.ClientFactory, "test-user-slug-1", "testUserPassword%v")
+	secondUserClient, _, err = test.LoggedInClient(clientFactory, "test-user-slug-1", "testUserPassword%v")
 	require.NoError(t, err)
 
 	t.Run("second user cannot invite as it has the role but does not own it", func(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -25,8 +25,6 @@ import (
 	"github.com/1backend/1backend/server/internal/di"
 )
 
-var port = router.GetPort()
-
 // @title           1Backend
 // @version         0.3.0-rc.30
 // @description     AI-native microservices platform.
@@ -59,6 +57,8 @@ func main() {
 	srv := &http.Server{
 		Handler: nodeInfo.Router,
 	}
+
+	port := router.GetPort()
 
 	logger.Info("Server started", slog.String("port", port))
 	go func() {

--- a/server/main.go
+++ b/server/main.go
@@ -48,26 +48,29 @@ import (
 // @externalDocs.description  1Backend API
 // @externalDocs.url          https://1backend.com/docs/category/1backend-api
 func main() {
-	nodeInfo, err := di.BigBang(&di.Options{})
+	logger.Info("Starting...")
+
+	universe, err := di.BigBang(&di.Options{})
 	if err != nil {
 		logger.Error("Cannot start node", slog.Any("error", err))
 		os.Exit(1)
 	}
 
 	srv := &http.Server{
-		Handler: nodeInfo.Router,
+		Handler: universe.Router,
 	}
 
 	port := router.GetPort()
 
-	logger.Info("Server started", slog.String("port", port))
 	go func() {
-		time.Sleep(5 * time.Millisecond)
-		err := nodeInfo.StarterFunc()
+		err := universe.StarterFunc()
 		if err != nil {
 			logger.Error("Cannot start universe", slog.Any("error", err))
 			os.Exit(1)
 		}
+
+		time.Sleep(5 * time.Millisecond)
+		logger.Info("Server started", slog.String("port", port))
 	}()
 
 	err = http.ListenAndServe(fmt.Sprintf(":%v", port), srv.Handler)


### PR DESCRIPTION
The goal is so microservices relying on the 1backend service can be tested easily.

For this this PR created helper function that launches the 1backend server with certain parameters like OB_DB_PREFIX, OB_CONFIG_FOLDER etc. to be able to run parallel tests of one's microservices.