### PR TITLE
refactor(server): replace golang.org/x/exp with stdlib

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/swaggo/swag v1.16.4
 	go.uber.org/mock v0.5.0
 	golang.org/x/crypto v0.36.0
-	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
 	golang.org/x/time v0.11.0
 )
 

--- a/server/go.sum
+++ b/server/go.sum
@@ -207,8 +207,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 h1:nDVHiLt8aIbd/VzvPWN6kSOPE7+F/fNFDSXLVYkE/Iw=
-golang.org/x/exp v0.0.0-20250305212735-054e65f0b394/go.mod h1:sIifuuw/Yco/y6yb6+bDNfyeQ/MdPUy/hKEMYQV17cM=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/server/internal/services/proxy/http_route.go
+++ b/server/internal/services/proxy/http_route.go
@@ -16,11 +16,11 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 
 	"github.com/pkg/errors"
-	"golang.org/x/exp/rand"
 
 	openapi "github.com/1backend/1backend/clients/go"
 	"github.com/1backend/1backend/sdk/go/client"
@@ -97,7 +97,7 @@ func (cs *ProxyService) route(w http.ResponseWriter, r *http.Request) (int, erro
 		selectedInstances = rsp.Instances
 	}
 
-	randomIndex := rand.Intn(len(selectedInstances))
+	randomIndex := rand.IntN(len(selectedInstances))
 	instance := selectedInstances[randomIndex]
 
 	uri := strings.TrimSuffix(instance.Url, "/") +

--- a/server/internal/services/secret/http_remove_secrets.go
+++ b/server/internal/services/secret/http_remove_secrets.go
@@ -15,6 +15,7 @@ package secretservice
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/1backend/1backend/sdk/go/datastore"
@@ -22,7 +23,6 @@ import (
 	"github.com/1backend/1backend/sdk/go/logger"
 	secret "github.com/1backend/1backend/server/internal/services/secret/types"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/slog"
 )
 
 // @Id removeSecrets

--- a/server/internal/services/secret/http_save_secrets.go
+++ b/server/internal/services/secret/http_save_secrets.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -30,7 +31,6 @@ import (
 	secret "github.com/1backend/1backend/server/internal/services/secret/types"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/blake2b"
-	"golang.org/x/exp/slog"
 )
 
 // @Id saveSecrets


### PR DESCRIPTION
- `golang.org/x/exp/slog`: Available in Go 1.21.
- `golang.org/x/exp/rand`: Available in Go 1.22. `golang.org/x/exp/rand` has been deprecated and scheduled to be deleted.

Reference: https://go.dev/doc/go1.21#slog
Reference: https://go.dev/doc/go1.22#math_rand_v2
Reference: https://github.com/golang/exp/commit/f9890c6ad9f380fd3cdb66a33843f522d4790e03