### PR TITLE
feat(image-svc): do not increase image size

### DIFF
--- a/server/internal/services/image/http_serve_uploaded_image.go
+++ b/server/internal/services/image/http_serve_uploaded_image.go
@@ -203,6 +203,11 @@ func (cs *ImageService) ServeUploadedImage(w http.ResponseWriter, r *http.Reques
 			targetHeight = origHeight
 		}
 
+		// Prevent enlargement
+		if targetWidth > origWidth || targetHeight > origHeight {
+			targetWidth, targetHeight = origWidth, origHeight
+		}
+
 		logger.Info("Resizing image",
 			slog.Int("width", width),
 			slog.Int("height", height),

--- a/server/internal/services/image/http_serve_uploaded_image_test.go
+++ b/server/internal/services/image/http_serve_uploaded_image_test.go
@@ -95,4 +95,17 @@ func TestServeUploadedImage(t *testing.T) {
 		require.Equal(t, 70, bounds.Dx())
 		require.Equal(t, 70, bounds.Dy())
 	})
+
+	t.Run("does not enlarge image", func(t *testing.T) {
+		rsp, _, err := adminClient.ImageSvcAPI.ServeUploadedImage(ctx, fileId).
+			Width(200).
+			Height(200).
+			Execute()
+		require.NoError(t, err)
+		img, _, err := image.Decode(rsp)
+		require.NoError(t, err)
+		bounds := img.Bounds()
+		require.Equal(t, 100, bounds.Dx())
+		require.Equal(t, 100, bounds.Dy())
+	})
 }


### PR DESCRIPTION
Not an overly sensible thing to do. If it turns out we need it we can introduce a request param like `enlarge`.